### PR TITLE
Run the solr java script in the background.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Write something about your project, roy.
 
 ## Options
-1. `background` - Add the 'background' word after the script to activate solr in the background. Example: `./solr.sh background`.
+1. `-b` - Add the flag to activate solr in the background. Example: `./solr.sh -b`.

--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 Write something about your project, roy.
 
 ## Options
-1. `-b` - Add the flag to activate solr in the background. Example: `./solr.sh -b`.
+1. `-b | --background` - Add the flag to activate solr in the background. Example: `./solr.sh -b`.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# solr-script
+Write something about your project, roy.
+
+## Options
+1. `background` - Add the 'background' word after the script to activate solr in the background. Example: `./solr.sh background`.

--- a/solr.sh
+++ b/solr.sh
@@ -23,7 +23,7 @@ cd -
 # Start the server.
 cd solr/example/
 
-#
+# Go through the flags.
 while test $# -gt 0; do
   case "$1" in
     -h|--help)
@@ -31,7 +31,6 @@ while test $# -gt 0; do
       echo "solr-script by roy segall"
       echo " "
       echo "options:"
-      echo "-h, --help                      show brief help"
       echo "-b, --background=TRUE/FALSE     specify if solr will execute in the background or not"
       exit 0
       ;;

--- a/solr.sh
+++ b/solr.sh
@@ -2,7 +2,7 @@
 
 # Download apache solr.
 if [ ! -f solr-4.7.2.zip ]; then
-  wget http://archive.apache.org/dist/lucene/solr/4.7.2/solr-4.7.2.zip 
+  wget http://archive.apache.org/dist/lucene/solr/4.7.2/solr-4.7.2.zip
 fi;
 
 # Exctracting apache solr from the zip file.
@@ -23,4 +23,4 @@ cd -
 # Start the server.
 cd solr/example/
 
-java -jar start.jar
+java -jar start.jar > /dev/null 2>&1 < /dev/null &

--- a/solr.sh
+++ b/solr.sh
@@ -23,8 +23,25 @@ cd -
 # Start the server.
 cd solr/example/
 
-if [ $1 = "background" ]; then
-  java -jar start.jar > /dev/null 2>&1 < /dev/null &
-else
-  java -jar start.jar
-fi
+#
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo " "
+      echo "solr-script by roy segall"
+      echo " "
+      echo "options:"
+      echo "-h, --help                      show brief help"
+      echo "-b, --background=TRUE/FALSE     specify if solr will execute in the background or not"
+      exit 0
+      ;;
+    -b|--background)
+      shift
+        java -jar start.jar > /dev/null 2>&1 < /dev/null &
+        exit 0
+      shift
+      ;;
+    esac
+done
+
+java -jar start.jar

--- a/solr.sh
+++ b/solr.sh
@@ -23,4 +23,8 @@ cd -
 # Start the server.
 cd solr/example/
 
-java -jar start.jar > /dev/null 2>&1 < /dev/null &
+if [ $1 = "background" ]; then
+  java -jar start.jar > /dev/null 2>&1 < /dev/null &
+else
+  java -jar start.jar
+fi


### PR DESCRIPTION
#1

@RoySegall With that fix, solr will work on the background.

Maybe it's good to add a readme file what will explain that and will explain how to close it (like `top | grep java` and then `kill <pid>`.
